### PR TITLE
Fix server crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Other:
 [deno guide](https://deno.land/#installation)
 
 Run the game server  
-`deno run --allow-net=:3000 --cached-only --allow-read main.ts --port=3000`
+`deno run --allow-net=:3000 --allow-read main.ts --port=3000`
 
 Use URL to connect: `http://localhost:3000`
 

--- a/client/js/client.js
+++ b/client/js/client.js
@@ -92,7 +92,11 @@ class Client {
         this.playerName = this.playerNameInput.value;
     
         if (this.playerName) {
-            this.ws = new WebSocket(`wss://${window.location.host}/ws`);
+            let socketProtocol = 'wss'
+            if (location.protocol !== 'https:') {
+                socketProtocol = 'ws'
+            }
+            this.ws = new WebSocket(`${socketProtocol}://${window.location.host}/ws`);
             this.initWebSocket();
         }
     }

--- a/server/clientHandler.ts
+++ b/server/clientHandler.ts
@@ -15,15 +15,16 @@ export class ClientHandler {
 
   private broadcastPlayerMove(player: Player, direction: string): void {
     player.move(direction, this.boardRows, this.boardColumns)
+    const data = JSON.stringify(this.players);
 
     for (const player of this.players.values()) {
-      player.clientWs.send(JSON.stringify(this.players))
+      player.clientWs.send(data)
     }
   }
 
   private broadcastPlayerConnection(playerId: string): void {
     for (const player of this.players.values()) {
-      player.clientWs.send(JSON.stringify({command: 'player-login', data: `> player with the id ${playerId} is connected`}))
+      player.clientWs.send(`{"command": 'player-login', "data": "> player with the id ${playerId} is connected"}`)
     }
   }
 

--- a/server/clientHandler.ts
+++ b/server/clientHandler.ts
@@ -17,13 +17,13 @@ export class ClientHandler {
     player.move(direction, this.boardRows, this.boardColumns)
     const data = JSON.stringify(this.players);
 
-    for (const player of this.players.values()) {
+    for (const player of this.players) {
       player.clientWs.send(data)
     }
   }
 
   private broadcastPlayerConnection(playerId: string): void {
-    for (const player of this.players.values()) {
+    for (const player of this.players) {
       player.clientWs.send(`{"command": 'player-login', "data": "> player with the id ${playerId} is connected"}`)
     }
   }


### PR DESCRIPTION
The crashes were mainly caused by a `JSON.stringfy` inside a loop draining memory. I couldn't find many info about why this happened and didn't find any benchmarking to, maybe, explain why such large memory usage happened with a simple 3x loop...

Fun fact: you may notice that we use `for...of` instead of `forEach`, I searched which was bettet and found out that `forEach` is actualy 24% **slower** than `for...of`! ([source](https://stackoverflow.com/questions/50844095/should-one-use-for-of-or-foreach-when-iterating-through-an-array))

You can test this fix [here](https://diguifi-tests-tiny-mmo.herokuapp.com/)