### PR TITLE
Change transferred data to lists

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -20,8 +20,8 @@ class Game {
     }
 
     applyServerRules(serverData) {
-        this.boardRows = serverData.boardRows;
-        this.boardColumns = serverData.boardColumns;
+        this.boardRows = serverData[2];
+        this.boardColumns = serverData[3];
         this.cellWidth = this.width / this.boardRows;
         this.cellHeight = this.height / this.boardColumns;
     }

--- a/server/player.ts
+++ b/server/player.ts
@@ -45,4 +45,14 @@ export class Player {
                 break;
         }
     }
+
+    public getReturnData() {
+        return {
+            id: this.id,
+            name: this.name,
+            color: this.color,
+            x: this.x,
+            y: this.y
+        }
+    }
 }


### PR DESCRIPTION
Resolves #24 

Before this PR all data was sent in the form of JSONs encoded as strings. Now all data is transferred only as an array, in which the first position is always the command and the other positions are the relevant data for that command. There is no parsing method yet, but will be implemented at issue #23

Besides that, a method at the player, on the server, was also created to ensure only relevant data is returned to the client whenever a new player logs in.

Here's a side by side comparison of how much data has been saved in a simple login:

![image](https://user-images.githubusercontent.com/31022286/82735762-77917580-9cfa-11ea-8d56-9dd297c657e7.png)

## You can test this PR [here](https://diguifi-tests-tiny-mmo.herokuapp.com/)