### PR TITLE
Divides layers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,13 +15,23 @@
       <sub>left click: draw / right click: erase</sub>
     </div>
     <div id="game">
-      <canvas id="canvas" width="200" height="200"></canvas>
-      <p>Players Online:</p>
-      <ul id="player-list"></ul>
+      <div id="layers">
+        <canvas id="background-layer" width="200" height="200" class="canvas-layer"></canvas>
+        <canvas id="sprites-layer" width="200" height="200" class="canvas-layer"></canvas>
+      </div>
+      <div id="game-info">
+        <p>Players Online:</p>
+        <ul id="player-list"></ul>
+      </div>
     </div>
   </div>
   <script src="js/client.js"></script>
   <script src="js/game.js"></script>
   <script src="js/main.js"></script>
+  <style>
+    .canvas-layer {
+      position: absolute;
+    }
+  </style>
   </body>
 </html>

--- a/client/js/client.js
+++ b/client/js/client.js
@@ -97,7 +97,7 @@ class Client {
 
     initPlayers(players) {
         this.game.addPlayers(players);
-        this.drawEntities();
+        this.drawSprites();
     }
 
     updatePlayer(data) {
@@ -106,16 +106,15 @@ class Client {
                 player.move(data[2], data[3]);
             }
         }
-        this.drawEntities();
+        this.drawSprites();
     }
 
-    drawEntities() {
-        while(this.playerListElement.firstChild ){
+    drawSprites() {
+        while(this.playerListElement.firstChild){
             this.playerListElement.removeChild(this.playerListElement.firstChild);
         }
     
-        this.game.ctx.clearRect(0, 0, this.game.c.width, this.game.c.height);
-        this.game.board.draw();
+        this.game.spritesLayer.clear();
 
         this.game.players.forEach(player => {
             const li = document.createElement("li");

--- a/client/js/client.js
+++ b/client/js/client.js
@@ -15,7 +15,6 @@ const Command = {
 class Client {
     constructor(game, clientConfigs, mainElements) {
         document.onkeydown = this.checkKey.bind(this);
-        this.playerListElement = mainElements.playerListElement;
         this.loginScreen = mainElements.loginScreen;
         this.gameScreen = mainElements.gameScreen;
         this.gameScreen.style.display='none';
@@ -64,12 +63,12 @@ class Client {
     onReceiveMessage(event) {
         const data = event.data;
         try {
-            const receivedData = data.split(',');
-            
+            const receivedData = this.parseEventDataString(data);
+
             switch (+receivedData[0]) {
                 case Command.Login:
                     this.game.applyServerRules(receivedData);
-                    this.initPlayers(this.getPlayerListFromData(data));
+                    this.initPlayers(JSON.parse(receivedData[4]));
                     break
                 case Command.Move:
                     this.updatePlayer(receivedData);
@@ -83,25 +82,29 @@ class Client {
         }
     }
 
-    //this will be much prettier when we have the parser, sorry
-    getPlayerListFromData(data) {
-        let rawDataString = data;
-        let listString = '';
-        if (data.includes(',[')) {
-          rawDataString = data.substr(0, data.indexOf(',['));
-          listString = data.substr(data.indexOf('['), data.length);
+    parseEventDataString(eventDataString) {
+        let rawDataString = eventDataString;
+        let matrix = '';
+        if (eventDataString.includes(',[')) {
+            rawDataString = eventDataString.substr(0, eventDataString.indexOf(',['));
+            matrix = eventDataString.substr(eventDataString.indexOf('['), eventDataString.length);
         }
-        const eventData = rawDataString.split(',')
-        return JSON.parse(listString);
+
+        let eventData = rawDataString.split(',');
+        if (matrix !== '') {
+            eventData.push(matrix);
+        }
+
+        return eventData;
     }
 
     initPlayers(players) {
-        this.game.addPlayers(players);
+        this.game.spritesLayer.addPlayers(players);
         this.drawSprites();
     }
 
     updatePlayer(data) {
-        for(const player of this.game.players) {
+        for(const player of this.game.spritesLayer.players) {
             if (player.id == data[1]) {
                 player.move(data[2], data[3]);
             }
@@ -110,20 +113,7 @@ class Client {
     }
 
     drawSprites() {
-        while(this.playerListElement.firstChild){
-            this.playerListElement.removeChild(this.playerListElement.firstChild);
-        }
-    
-        this.game.spritesLayer.clear();
-
-        this.game.players.forEach(player => {
-            const li = document.createElement("li");
-            li.appendChild(document.createTextNode(player.name));
-            li.style.color = player.color;
-            this.playerListElement.appendChild(li);
-
-            player.draw();
-        });
+        this.game.spritesLayer.draw();
     }
 
     checkKey(e) {

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -1,20 +1,17 @@
 class Game {
     constructor(gameConfigs, mainElements) {
-        this.c = document.getElementById('canvas');
-        this.ctx = this.c.getContext('2d');
-
         this.width = gameConfigs.width;
         this.height = gameConfigs.height;
         this.boardRows = 5;
         this.boardColumns = 5;
-        this.ctx.canvas.width = this.width;
-        this.ctx.canvas.height = this.height;
         this.cellWidth = this.width / this.boardRows;
         this.cellHeight = this.height / this.boardColumns;
 
-        this.board = new Board(this)
+        this.backgroundLayer = new BackgroundLayer(this);
+        this.spritesLayer = new SpritesLayer(this);
+
+        this.board = new Board(this, this.backgroundLayer);
         this.players = [];
-        this.board.draw();
     }
 
     applyServerRules(serverData) {
@@ -22,37 +19,43 @@ class Game {
         this.boardColumns = serverData[3];
         this.cellWidth = this.width / this.boardRows;
         this.cellHeight = this.height / this.boardColumns;
+
+        this.board.draw();
     }
 
     addPlayers(players) {
         this.players.splice(0, this.players.length);
         for(const player of players) {
-            this.players.push(new Player(this, player));
+            this.players.push(new Player(this, player, this.spritesLayer));
         }
     }
 }
 
 class Board {
-    constructor(game) {
+    constructor(game, layer) {
         this.game = game;
+        this.layer = layer;
     }
 
     draw() {
+        this.layer.clear();
+
         let i = 0;
         let j = 0;
         for (i = 0; i < this.game.boardRows; i++) {
             for (j = 0; j < this.game.boardColumns; j++) {
-                this.game.ctx.beginPath();
-                this.game.ctx.rect(i * this.game.cellWidth, j * this.game.cellHeight, this.game.cellWidth, this.game.cellHeight);
-                this.game.ctx.stroke();
+                this.layer.ctx.beginPath();
+                this.layer.ctx.rect(i * this.game.cellWidth, j * this.game.cellHeight, this.game.cellWidth, this.game.cellHeight);
+                this.layer.ctx.stroke();
             }
         }
     }
 }
 
 class Player {
-    constructor(game, playerData) {
+    constructor(game, playerData, layer) {
         this.game = game;
+        this.layer = layer;
 
         this.x = playerData.x;
         this.y = playerData.y;
@@ -66,25 +69,55 @@ class Player {
     }
 
     draw() {
-        this.game.ctx.beginPath();
+        this.layer.ctx.beginPath();
 
         for (let column = 0; column < this.playerSize; column++) {
             for (let line = 0; line < this.playerSize; line++) {
                 const draw = this.playerMatrix[line][column];
                 if (draw) {
-                    this.game.ctx.fillStyle = this.color;
+                    this.layer.ctx.fillStyle = this.color;
                     const startX = (column * this.game.cellWidth / this.playerSize) + (this.x * this.game.cellWidth);
                     const startY = (line * this.game.cellHeight / this.playerSize) + (this.y * this.game.cellHeight);
-                    this.game.ctx.fillRect(startX, startY, this.game.cellWidth / this.playerSize, this.game.cellHeight / this.playerSize);
+                    this.layer.ctx.fillRect(startX, startY, this.game.cellWidth / this.playerSize, this.game.cellHeight / this.playerSize);
                 } 
             }
         }
 
-        this.game.ctx.stroke();
+        this.layer.ctx.stroke();
     }
 
     move(x, y) {
         this.x = x;
         this.y = y;
+    }
+}
+
+class SpritesLayer {
+    constructor(game) {
+        this.game = game;
+
+        this.c = document.getElementById('sprites-layer');
+        this.ctx = this.c.getContext('2d');
+        this.ctx.canvas.width = this.game.width;
+        this.ctx.canvas.height = this.game.height;
+    }
+
+    clear() {
+        this.ctx.clearRect(0, 0, this.c.width, this.c.height);
+    }
+}
+
+class BackgroundLayer {
+    constructor(game) {
+        this.game = game;
+
+        this.c = document.getElementById('background-layer');
+        this.ctx = this.c.getContext('2d');
+        this.ctx.canvas.width = this.game.width;
+        this.ctx.canvas.height = this.game.height;
+    }
+
+    clear() {
+        this.ctx.clearRect(0, 0, this.c.width, this.c.height);
     }
 }

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -11,7 +11,6 @@ class Game {
         this.spritesLayer = new SpritesLayer(this);
 
         this.board = new Board(this, this.backgroundLayer);
-        this.players = [];
     }
 
     applyServerRules(serverData) {
@@ -21,13 +20,6 @@ class Game {
         this.cellHeight = this.height / this.boardColumns;
 
         this.board.draw();
-    }
-
-    addPlayers(players) {
-        this.players.splice(0, this.players.length);
-        for(const player of players) {
-            this.players.push(new Player(this, player, this.spritesLayer));
-        }
     }
 }
 
@@ -96,14 +88,46 @@ class SpritesLayer {
     constructor(game) {
         this.game = game;
 
+        this.playerListElement = document.getElementById('player-list');
         this.c = document.getElementById('sprites-layer');
         this.ctx = this.c.getContext('2d');
         this.ctx.canvas.width = this.game.width;
         this.ctx.canvas.height = this.game.height;
+
+        this.players = [];
+        // next we will have: this.enemies, this.warps, this.trees, etc...
+    }
+
+    draw() {
+        this.ctx.clearRect(0, 0, this.c.width, this.c.height);
+        this.drawPlayers();
+        // this.drawEnemies, this.drawWarps, ...
     }
 
     clear() {
         this.ctx.clearRect(0, 0, this.c.width, this.c.height);
+    }
+
+    addPlayers(players) {
+        this.players.splice(0, this.players.length);
+        for(const player of players) {
+            this.players.push(new Player(this.game, player, this));
+        }
+    }
+
+    drawPlayers() {
+        while(this.playerListElement.firstChild){
+            this.playerListElement.removeChild(this.playerListElement.firstChild);
+        }
+
+        this.players.forEach(player => {
+            const li = document.createElement("li");
+            li.appendChild(document.createTextNode(player.name));
+            li.style.color = player.color;
+            this.playerListElement.appendChild(li);
+
+            player.draw();
+        });
     }
 }
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -3,9 +3,12 @@ class Main {
     this.playerListElement = document.getElementById('player-list');
     this.loginScreen = document.getElementById('login');
     this.playerNameInput = document.getElementById('player-name');
-    this.confirmBtn = document.getElementById('confirm-btn')
+    this.confirmBtn = document.getElementById('confirm-btn');
     this.gameScreen = document.getElementById('game');
     this.gameScreen.style.display='none';
+    this.layersParentElement = document.getElementById('layers');
+    this.layersParentElement.style.width = `${configs.game.width}px`;
+    this.layersParentElement.style.height = `${configs.game.height}px`;
     
     this.drawingGrid = new DrawingCanvas(this, configs.drawingGrid);
 

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1,6 +1,5 @@
 class Main {
   constructor(configs) {
-    this.playerListElement = document.getElementById('player-list');
     this.loginScreen = document.getElementById('login');
     this.playerNameInput = document.getElementById('player-name');
     this.confirmBtn = document.getElementById('confirm-btn');

--- a/server/clientHandler.ts
+++ b/server/clientHandler.ts
@@ -59,7 +59,9 @@ export class ClientHandler {
     }
 
     let eventData = rawDataString.split(',')
-    eventData.push(matrix)
+    if (matrix !== '') {
+      eventData.push(matrix)
+    }
 
     return eventData
   }


### PR DESCRIPTION
Separate background layer from sprites layer.

With this update, the client becomes way more performatic (graphics wise, not network), by avoiding 2 nested for's that used to draw the board at each movement. Now the board (and any background graphic) is separated on the "BackgroundLayer", and any movable, interactable entity is at the "SpritesLayer". Both are isolated canvases.